### PR TITLE
Pull Request for features/training-page

### DIFF
--- a/src/features/training/index.jsx
+++ b/src/features/training/index.jsx
@@ -49,6 +49,11 @@ function Training({
     setEditedUsers({});
   };
 
+  const handleLogSave = async () => {
+    await saveLogNotes(Object.values(editedUsers));
+    setEditedUsers({});
+  };
+
   const uniqueEntries = new Set();
 
   const trainees = [
@@ -168,10 +173,6 @@ function Training({
       await processTrainees([newData.Employee_Name]);
     }
   };
-  
-  
-  
-  
   
   const masterForm = useForm({
     initialValues: { date: null, trainer: null, trainingDesc: null, trainingTitle: null, trainingType: null, needsRepeat: null, repeatAfter: null, trainees: null },
@@ -394,7 +395,7 @@ function Training({
           enableGrouping={false}
           isEditable={true}
           isEdited={Object.keys(editedUsers).length === 0}
-          handleSave={handleSaveUsers}
+          handleSave={handleLogSave}
           hasCustomActionBtn={true}
         >
           <Box display={"flex"}>

--- a/src/features/training/store/names_store/reducer.js
+++ b/src/features/training/store/names_store/reducer.js
@@ -1,22 +1,22 @@
 const INITIAL_STATE = {
-    names: [],
-    namesLoading: false,
-  };
+  names: [],
+  namesLoading: false,
+};
   
 export const namesReducer = (state = INITIAL_STATE, action) => {
-    switch (action.type) {
-      case 'SET_NAMES':
-        return {
-            ...state,
-            names: [...action.payload],
-        };
-      case 'SET_NAMES':
-        return {
-            ...state,
-            namesLoading: action.payload,
-        };
-        default:
-    return state;
+  switch (action.type) {
+    case 'SET_NAMES':
+      return {
+        ...state,
+        names: [...action.payload],
+      };
+    case 'SET_NAMES_LOADING':
+      return {
+        ...state,
+        namesLoading: action.payload,
+      };
+      default:
+        return state;
   }
 };
 


### PR DESCRIPTION
FIX: Proper Saving for Master/Log Training Tables. Previously, if a training log was edited, it would save to a new row in the Master_Training DB.